### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -29,8 +29,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-Webhooks.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-webhooks
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ directory = invenio_webhooks/translations/
 
 [extract_messages]
 copyright_holder = CERN
-msgid_bugs_address = info@invenio-software.org
+msgid_bugs_address = info@inveniosoftware.org
 mapping-file = babel.ini
 output-file = invenio_webhooks/translations/messages.pot
 add-comments = NOTE

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
     keywords='invenio webhooks',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-webhooks',
     packages=packages,
     zip_safe=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,7 +104,7 @@ def tester_id(app):
     with app.app_context():
         datastore = app.extensions['security'].datastore
         tester = datastore.create_user(
-            email='info@invenio-software.org', password='tester',
+            email='info@inveniosoftware.org', password='tester',
         )
         db.session.commit()
         tester_id = tester.id


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>