### PR TITLE
views: use current_user instead of request.oauth

### DIFF
--- a/invenio_webhooks/views.py
+++ b/invenio_webhooks/views.py
@@ -32,6 +32,7 @@ from functools import wraps
 from flask import Blueprint, abort, jsonify, request
 from flask.views import MethodView
 from flask_babelex import lazy_gettext as _
+from flask_security import current_user
 from invenio_db import db
 from invenio_oauth2server import require_api_auth, require_oauth_scopes
 from invenio_oauth2server.models import Scope
@@ -93,7 +94,7 @@ class ReceiverEventListResource(MethodView):
         """Handle POST request."""
         event = Event.create(
             receiver_id=receiver_id,
-            user_id=request.oauth.access_token.user_id
+            user_id=current_user.id
         )
         db.session.add(event)
         db.session.commit()


### PR DESCRIPTION
* FIX Uses `current_user` instead of `request.oauth` to get the user's
  id. invenio-oauth2server authenticates using the passed access_token
  and sets current_user from an `app.before_request` for REST calls.

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>