### PR TITLE
global: default webhook url pattern fix

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,18 +27,15 @@ API Docs
 
 .. automodule:: invenio_webhooks.ext
    :members:
-   :undoc-members:
 
 .. automodule:: invenio_webhooks.models
    :members:
-   :undoc-members:
 
 Configuration
 -------------
 
 .. automodule:: invenio_webhooks.config
    :members:
-   :undoc-members:
 
 
 Signatures
@@ -46,18 +43,15 @@ Signatures
 
 .. automodule:: invenio_webhooks.signatures
    :members:
-   :undoc-members:
 
 REST API
 --------
 
 .. automodule:: invenio_webhooks.views
    :members:
-   :undoc-members:
 
 Proxies
 -------
 
 .. automodule:: invenio_webhooks.proxies
    :members:
-   :undoc-members:

--- a/invenio_webhooks/views.py
+++ b/invenio_webhooks/views.py
@@ -113,6 +113,6 @@ class ReceiverEventListResource(MethodView):
 #
 view = ReceiverEventListResource.as_view('event_list')
 blueprint.add_url_rule(
-    '/receivers/<string:receiver_id>/events/',
+    '/hooks/receivers/<string:receiver_id>/events/',
     view_func=view,
 )


### PR DESCRIPTION
* Changed the webhook URL pattern to match the legacy.

Signed-off-by: Krzysztof Nowak <k.nowak@cern.ch>