### PR TITLE
models: serializable event ID in CeleryReceiver

### DIFF
--- a/invenio_webhooks/models.py
+++ b/invenio_webhooks/models.py
@@ -168,7 +168,7 @@ class CeleryReceiver(Receiver):
 
     def __call__(self, event):
         """Fire a celery task."""
-        process_event.apply_async(task_id=str(event.id), args=[event.id])
+        process_event.apply_async(task_id=str(event.id), args=[str(event.id)])
 
     def status(self, event):
         """Return a tuple with current processing status code and message."""


### PR DESCRIPTION
* Fixes serialization issue when the event ID is passed as an argument
  to the `process_event` task from a CeleryReceiver. (closes #42)

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>