### PR TITLE
models: raise NotImplemented fix

### DIFF
--- a/invenio_webhooks/models.py
+++ b/invenio_webhooks/models.py
@@ -69,7 +69,7 @@ class Receiver(object):
 
     def run(self, event):
         """Implement method accepting the ``Event`` instance."""
-        raise NotImplemented()
+        raise NotImplemented
 
     def status(self, event):
         """Return a tuple with current processing status code and message.


### PR DESCRIPTION
* Fixes a minor issue, which occured in the error-handling code, when
  the `run` function of a `Receiver` was not implemented. (closes #44)

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>