### PR TITLE
fix(chore): DeprecationWarning stdlib

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,11 @@
 Changes
 =======
 
+Version v2.0.0 (released 2026-01-29)
+
+- chore(setup): bump dependencies
+- fix(chore): DeprecationWarning stdlib
+
 Version v1.1.1 (released 2026-01-29)
 
 - chore(setup): pin dependencies

--- a/invenio_webhooks/__init__.py
+++ b/invenio_webhooks/__init__.py
@@ -29,7 +29,7 @@ from .ext import InvenioWebhooks
 from .models import Receiver
 from .proxies import current_webhooks
 
-__version__ = "1.1.1"
+__version__ = "2.0.0"
 
 __all__ = (
     "__version__",

--- a/invenio_webhooks/alembic/201faeb649c7_change_datetime_types.py
+++ b/invenio_webhooks/alembic/201faeb649c7_change_datetime_types.py
@@ -1,0 +1,50 @@
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+# Copyright (C) 2026 Graz University of Technology.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Change expires_at type to utc aware datetime."""
+
+from invenio_db.utils import (
+    update_table_columns_column_type_to_datetime,
+    update_table_columns_column_type_to_utc_datetime,
+)
+
+# revision identifiers, used by Alembic.
+revision = "201faeb649c7"
+down_revision = "a095bd179f5c"
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    for table_name in ["webhooks_events"]:
+        update_table_columns_column_type_to_utc_datetime(table_name, "created")
+        update_table_columns_column_type_to_utc_datetime(table_name, "updated")
+
+
+def downgrade():
+    """Downgrade database."""
+    for table_name in ["webhooks_events"]:
+        update_table_columns_column_type_to_datetime(table_name, "created")
+        update_table_columns_column_type_to_datetime(table_name, "updated")

--- a/invenio_webhooks/models.py
+++ b/invenio_webhooks/models.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2014, 2015, 2016 CERN.
+# Copyright (C) 2026 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -35,7 +36,7 @@ from invenio_db import db
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import validates
 from sqlalchemy.orm.attributes import flag_modified
-from sqlalchemy_utils import JSONType, Timestamp, UUIDType
+from sqlalchemy_utils import JSONType, UUIDType
 
 from . import signatures
 from ._compat import delete_cached_json_for
@@ -208,7 +209,7 @@ def _json_column(**kwargs):
     )
 
 
-class Event(db.Model, Timestamp):
+class Event(db.Model, db.Timestamp):
     """Incoming webhook event data.
 
     Represents webhook event data which consists of a payload and a user id.

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,17 +56,17 @@ zip_safe = False
 install_requires =
     invenio-base>=2.3.0,<3.0.0
     invenio-i18n>=1.3.2,<4.0.0
-    invenio-oauthclient>=2.0.1,<7.0.0
-    invenio-oauth2server>=1.3.6,<4.0.0
+    invenio-oauthclient>=7.0.0,<8.0.0
+    invenio-oauth2server>=4.0.0,<5.0.0
 
 [options.extras_require]
 tests =
-    pytest-black>=0.3.0
-    invenio-app>=1.3.2,<3.0.0
+    pytest-black>=0.6.0
+    invenio-app>=3.0.0,<4.0.0
     invenio-celery>=1.2.4,<3.0.0
-    invenio-db[postgresql,mysql,versioning]>=1.0.14,<3.0.0
+    invenio-db[postgresql,mysql,versioning]>=2.2.0,<3.0.0
     invenio-cli>=1.0.5
-    pytest-invenio>=1.4.13,<4.0.0
+    pytest-invenio>=4.0.0,<5.0.0
     sphinx>=4.2.0
     # pytest-cache>=1.0
     # iniconfig>=1.1.1


### PR DESCRIPTION
* datetime.datetime.utcnow() is deprecated and scheduled for removal in
  a future version. Use timezone-aware objects to represent datetimes in
  UTC: datetime.datetime.now(datetime.UTC).

* the decision was made to move to utc aware timestamps
