### PR TITLE
fix: fixing the migration dependency to invenio-db package

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,12 @@
 Changes
 =======
 
+Version v3.0.0 (released 2026-05-29)
+
+- chore(setup): bump dependencies
+- chore(tests): add tests for alembic
+- fix: fixing the migration dependency to invenio-db package
+
 Version v2.0.0 (released 2026-01-29)
 
 - chore(setup): bump dependencies

--- a/invenio_webhooks/__init__.py
+++ b/invenio_webhooks/__init__.py
@@ -29,7 +29,7 @@ from .ext import InvenioWebhooks
 from .models import Receiver
 from .proxies import current_webhooks
 
-__version__ = "2.0.0"
+__version__ = "3.0.0"
 
 __all__ = (
     "__version__",

--- a/invenio_webhooks/alembic/469925575192_create_webhooks_branch.py
+++ b/invenio_webhooks/alembic/469925575192_create_webhooks_branch.py
@@ -1,6 +1,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2016 CERN.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -28,9 +29,14 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "469925575192"
-down_revision = "12a88921ada2"
+down_revision = None
 branch_labels = ("invenio_webhooks",)
-depends_on = "dbdbc1b19cf2"
+depends_on = [
+    # invenipo-db
+    "dbdbc1b19cf2",
+    # invenio_oauth2server/alembic/12a88921ada2_create_oauth2server_tables.py
+    "12a88921ada2",
+]
 
 
 def upgrade():

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,8 +56,8 @@ zip_safe = False
 install_requires =
     invenio-base>=2.3.0,<3.0.0
     invenio-i18n>=1.3.2,<4.0.0
-    invenio-oauthclient>=7.0.0,<8.0.0
-    invenio-oauth2server>=4.0.0,<5.0.0
+    invenio-oauthclient>=8.0.0,<9.0.0
+    invenio-oauth2server>=5.0.0,<6.0.0
 
 [options.extras_require]
 tests =

--- a/tests/test_alembic.py
+++ b/tests/test_alembic.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015-2020 CERN.
+# Copyright (C) 2026 CESNET z.s.p.o.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+
+"""Alembic upgrade tests."""
+
+import pytest
+from invenio_db import db
+
+
+def test_alembic(app):
+    """Test alembic recipes."""
+    ext = app.extensions["invenio-db"]
+
+    with app.app_context():
+        if db.engine.name == "sqlite":
+            raise pytest.skip("Upgrades are not supported on SQLite.")
+
+        assert not ext.alembic.compare_metadata()
+        db.drop_all()
+        ext.alembic.upgrade()
+
+        assert not ext.alembic.compare_metadata()
+
+        #
+        # Can not perform downgrade test because alembic has a curious behaviour/bug:
+        # if the revision id looks like a number, it is treated as a number of steps
+        # to perform and not as a revision id. So this downgrade would like to downgrade
+        # by a billion of steps which would fail.
+        #
+        # ext.alembic.downgrade(target="469925575192")
+        # ext.alembic.upgrade()
+
+        # assert not ext.alembic.compare_metadata()


### PR DESCRIPTION
### Description

The alembic migration that creates `webhooks` branch used `invenio-oauth2server` as a downstream, creating multiple heads for the `oauth2server` branch. This fix removes the downstream and moves the dependency to `depends_on`. 

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
